### PR TITLE
Fix typo in net units

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Units:
 - `clock` is measured in  `Mhz`.
 - `ram` is `MiB`.
 - `storage` is `GiB`.
-- `network` is `Gbps`.
+- `network` is `Mbps`.
 - `state` is one of `"Stopped"`, `"Starting"`, `"Running"`, `"Stopping"`.
 
 ## Testing


### PR DESCRIPTION
Sample VMs use 1000 and 10000 so those are Mbps, basically 1Gbps and 10Gbps, not 1000Gbps and 10kGbps